### PR TITLE
chore(version): bump to 0.9.4 and add release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "cauldron"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "article_scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cauldron"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Alessio Biancalana <alessio@dottorblaster.it>"]
 edition = "2021"
 publish = false

--- a/data/it.dottorblaster.cauldron.metainfo.xml.in.in
+++ b/data/it.dottorblaster.cauldron.metainfo.xml.in.in
@@ -35,6 +35,16 @@
   <url type="translate">https://github.com/dottorblaster/cauldron/tree/master/po</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.9.4" date="2026-02-07">
+      <description translatable="no">
+        <p>This release includes new features and improvements:</p>
+        <ul>
+          <li>Spanish (es) localization</li>
+          <li>Italian (it) localization</li>
+          <li>Updated dependencies for improved stability and security</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.9.3" date="2026-01-05">
       <description translatable="no">
         <p>This release includes new features and improvements:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'cauldron',
   'rust',
-  version: '0.9.3',
+  version: '0.9.4',
   meson_version: '>= 0.59',
   # license: 'MIT',
 )


### PR DESCRIPTION
Bumping to the latest (0.9.4) release.